### PR TITLE
Issue/6: Implement new export() in OdsExporter.java

### DIFF
--- a/main/src/com/google/refine/exporters/CustomizableTabularExporterUtilities.java
+++ b/main/src/com/google/refine/exporters/CustomizableTabularExporterUtilities.java
@@ -81,6 +81,26 @@ abstract public class CustomizableTabularExporterUtilities {
             final TabularSerializer serializer) {
 
         String optionsString = (params != null) ? params.getProperty("options") : null;
+        
+        
+        exportRowsWithOptionsString(project, engine, serializer, optionsString);
+    }
+
+    static public void exportRows(
+            final Project project,
+            final Engine engine,
+            Map<String, String> params,
+            final TabularSerializer serializer) {
+
+        String optionsString = (params != null) ? params.get("options") : null;
+        
+        
+        exportRowsWithOptionsString(project, engine, serializer, optionsString);
+    }
+
+    private static void exportRowsWithOptionsString(final Project project, final Engine engine, final TabularSerializer serializer,
+            String optionsString) {
+
         JsonNode optionsTemp = null;
         if (optionsString != null) {
             try {

--- a/main/src/com/google/refine/exporters/OdsExporter.java
+++ b/main/src/com/google/refine/exporters/OdsExporter.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -50,7 +51,7 @@ import com.google.refine.browsing.Engine;
 import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 
-public class OdsExporter implements StreamExporter {
+public class OdsExporter implements StreamExporter2 {
 
     @Override
     public String getContentType() {
@@ -58,16 +59,53 @@ public class OdsExporter implements StreamExporter {
     }
 
     @Override
+    public void export(Project project, Map<String, String> params, Engine engine, 
+            OutputStream outputStream) throws IOException {
+        final OdfSpreadsheetDocument odfDoc = getOdfDoc();
+
+        TabularSerializer serializer = getSerializer(project, odfDoc);
+
+        CustomizableTabularExporterUtilities.exportRows(
+                project, engine, params, serializer);
+
+        try {
+            odfDoc.save(outputStream);
+        } catch (Exception e) {
+            throw new IOException("Error saving spreadsheet", e);
+        }
+        outputStream.flush();
+    }
+
+    @Override
     public void export(final Project project, Properties params, Engine engine,
             OutputStream outputStream) throws IOException {
 
+        final OdfSpreadsheetDocument odfDoc = getOdfDoc();
+
+        TabularSerializer serializer = getSerializer(project, odfDoc);
+
+        CustomizableTabularExporterUtilities.exportRows(
+                project, engine, params, serializer);
+
+        try {
+            odfDoc.save(outputStream);
+        } catch (Exception e) {
+            throw new IOException("Error saving spreadsheet", e);
+        }
+        outputStream.flush();
+    }
+
+    private OdfSpreadsheetDocument getOdfDoc() throws IOException {
         final OdfSpreadsheetDocument odfDoc;
         try {
             odfDoc = OdfSpreadsheetDocument.newSpreadsheetDocument();
         } catch (Exception e) {
             throw new IOException("Failed to create spreadsheet", e);
         }
+        return odfDoc;
+    }
 
+    private TabularSerializer getSerializer(final Project project, final OdfSpreadsheetDocument odfDoc) {
         TabularSerializer serializer = new TabularSerializer() {
 
             OdfTable table;
@@ -131,16 +169,10 @@ public class OdsExporter implements StreamExporter {
                 }
             }
         };
-
-        CustomizableTabularExporterUtilities.exportRows(
-                project, engine, params, serializer);
-
-        try {
-            odfDoc.save(outputStream);
-        } catch (Exception e) {
-            throw new IOException("Error saving spreadsheet", e);
-        }
-        outputStream.flush();
+        return serializer;
     }
+
+
+
 
 }


### PR DESCRIPTION
Fixes #6 and #9 

Created new helper method `getSerializer(project, odfDoc)` to decrease code duplication between the new and old export method



